### PR TITLE
 Fix parsing of floats that run together in a backward compatible array

### DIFF
--- a/grammar/extxyz_kv_grammar.py
+++ b/grammar/extxyz_kv_grammar.py
@@ -20,7 +20,7 @@ exp = r'(?:[dDeE]'+opt_sign+r'[0-9]+)?'
 # rather tricky to match ending in various circumstances
 # first option is to end with a digit, which cannot be followed by a ., and then must be followed by a word break
 # second option is to end with a ., but that cannot be followed by another valid float character i.e. digit, exponent, or sign
-num_end = r'(?:(?<=\d)(?!\.)\b|(?=\.)(?![0-9dDeE+\-]))'
+num_end = r'(?:(?<=\d)(?!\.)\b|(?<=\.)(?![0-9dDeE+\-]))'
 float_re = opt_sign + r'(?:' + float_dec + exp + r'|' + bare_int + exp + r'|' + bare_int + r')' + num_end
 # int can't have \b at the beginning, causes parser to not include sign as part of regexp match
 # \b at end ensures that parser does not consider only initial digit of number as a complete match

--- a/grammar/extxyz_kv_grammar.py
+++ b/grammar/extxyz_kv_grammar.py
@@ -17,8 +17,10 @@ bare_int = r'(?:0|[1-9][0-9]*)'
 opt_sign = r'[+-]?'
 float_dec = r'(?:'+bare_int+r'\.|\.)[0-9]*'
 exp = r'(?:[dDeE]'+opt_sign+r'[0-9]+)?'
-# can't put \b at the end, because that won't match after non-word '.'
-num_end = r'(?:\b|(?=\W)|$)'
+# rather tricky to match ending in various circumstances
+# first option is to end with a digit, which cannot be followed by a ., and then must be followed by a word break
+# second option is to end with a ., but that cannot be followed by another valid float character i.e. digit, exponent, or sign
+num_end = r'(?:(?<=\d)(?!\.)\b|(?=\.)(?![0-9dDeE+\-]))'
 float_re = opt_sign + r'(?:' + float_dec + exp + r'|' + bare_int + exp + r'|' + bare_int + r')' + num_end
 # int can't have \b at the beginning, causes parser to not include sign as part of regexp match
 # \b at end ensures that parser does not consider only initial digit of number as a complete match

--- a/grammar/extxyz_kv_grammar.py
+++ b/grammar/extxyz_kv_grammar.py
@@ -18,8 +18,8 @@ opt_sign = r'[+-]?'
 float_dec = r'(?:'+bare_int+r'\.|\.)[0-9]*'
 exp = r'(?:[dDeE]'+opt_sign+r'[0-9]+)?'
 # rather tricky to match ending in various circumstances
-# first option is to end with a digit, which cannot be followed by a ., and then must be followed by a word break
-# second option is to end with a ., but that cannot be followed by another valid float character i.e. digit, exponent, or sign
+# first option is to end with a digit that cannot be followed by a ., and then must be followed by a word break
+# second option is to end with a . that cannot be followed by a word character (alphanumeric or underscore)
 num_end = r'(?:(?<=\d)(?!\.)\b|(?<=\.)(?!\w))'
 float_re = opt_sign + r'(?:' + float_dec + exp + r'|' + bare_int + exp + r'|' + bare_int + r')' + num_end
 # int can't have \b at the beginning, causes parser to not include sign as part of regexp match

--- a/grammar/extxyz_kv_grammar.py
+++ b/grammar/extxyz_kv_grammar.py
@@ -20,7 +20,7 @@ exp = r'(?:[dDeE]'+opt_sign+r'[0-9]+)?'
 # rather tricky to match ending in various circumstances
 # first option is to end with a digit, which cannot be followed by a ., and then must be followed by a word break
 # second option is to end with a ., but that cannot be followed by another valid float character i.e. digit, exponent, or sign
-num_end = r'(?:(?<=\d)(?!\.)\b|(?<=\.)(?![0-9dDeE+\-]))'
+num_end = r'(?:(?<=\d)(?!\.)\b|(?<=\.)(?!\w))'
 float_re = opt_sign + r'(?:' + float_dec + exp + r'|' + bare_int + exp + r'|' + bare_int + r')' + num_end
 # int can't have \b at the beginning, causes parser to not include sign as part of regexp match
 # \b at end ensures that parser does not consider only initial digit of number as a complete match

--- a/tests/test_kv_parsing_backward_compat_old_style_array.py
+++ b/tests/test_kv_parsing_backward_compat_old_style_array.py
@@ -39,3 +39,10 @@ def test_old_nine_elem_non_symm_Lattice(tmp_path, helpers):
     for at in helpers.read_all_variants(tmp_path / Path('test_file.extxyz')):
         # print("old format got cell", at.cell)
         assert np.all(at.cell == [[1,2,3], [4,5,6], [7,8,9]])
+
+
+def test_failing_runon_floats(tmp_path, helpers):
+    # not valid arrays of floats, should parse as strings
+    helpers.do_test_kv_pair(tmp_path, 'lat', '1.0 2.0 3.0   4.0 5.0 6.0   7.0 8.09.0', 'lat="1.0 2.0 3.0   4.0 5.0 6.0   7.0 8.09.0"')
+
+    helpers.do_test_kv_pair(tmp_path, 'lat', '1.0 2.0 3.0   4.0 5.0 6.0   7.0 8.0e39.0', 'lat="1.0 2.0 3.0   4.0 5.0 6.0   7.0 8.0e39.0"')


### PR DESCRIPTION
Fix end of float regexp to prevent `0.05.44` from being parsed as `0.05` followed by `.44` in a backward compatible array of floats (since `Repeat` doesn't require separation between Regex elements) .  Add corresponding test.

closes #6 