### PR TITLE
Fix reading of long lines, and add an ASE test with a long header line

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,7 +46,7 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y  gfortran libblas-dev liblapack-dev \
           openmpi-bin libopenmpi-dev netcdf-bin libnetcdf-dev libhdf5-serial-dev \
-          python-numpy
+          python3-numpy
         git clone --recursive https://github.com/libAtoms/QUIP QUIP
         mkdir -p QUIP/build/${QUIP_ARCH}
         cp QUIP/.github/workflows/Makefile.inc QUIP/build/${QUIP_ARCH}/Makefile.inc

--- a/libextxyz/extxyz.c
+++ b/libextxyz/extxyz.c
@@ -560,7 +560,7 @@ char *read_line(char **line, unsigned long *line_len, FILE *fp) {
             exit(1);
         }
 
-        stat = fgets(*line + *line_len - STR_INCR - 1, STR_INCR, fp);
+        stat = fgets(*line + *line_len - STR_INCR - 1, STR_INCR + 1, fp);
         if (!stat) {
             return 0;
         }

--- a/tests/test_ase_cases.py
+++ b/tests/test_ase_cases.py
@@ -319,6 +319,27 @@ def test_stress(tmp_path, helpers):
             assert abs(b.arrays['stress'] - np.arange(6, dtype=float)).max() < 1e-6
             assert 'stress' not in b.info
 
+def test_long_header_line(tmp_path):
+    test_float = [1.23825828523822]
+    test_float_s = ""
+    while len(test_float_s) < 3000:
+        test_float = test_float + test_float
+        test_float_s = ' '.join([str(f) for f in test_float])
+    test_float = np.asarray(test_float)
+    with open(tmp_path / "long_header.xyz", "w") as fout:
+        fout.write('1\n')
+        fout.write('Lattice="2.0 0.0 0.0   0.0 2.0 0.0   0.0 0.0 2.0" pbc="T T T" Properties=species:S:1:pos:R:3 test_float_a="' +
+                    test_float_s + '"\n')
+        fout.write('H 0.0 0.0 0.0\n')
+
+    lengths = []
+    with open(tmp_path / "long_header.xyz") as fin:
+        for l in fin:
+            print(l, end='')
+            lengths.append(len(l))
+    print("lengths", lengths)
+    at = read(tmp_path / "long_header.xyz")
+    assert at.info["test_float_a"] == pytest.approx(test_float)
 
 # no constraint I/O support yet
 ##@pytest.mark.parametrize('constraint', [FixAtoms(indices=(0, 2)),


### PR DESCRIPTION
Off by one error broke reading of lines that required the line string to be extended more than once.