### PR TITLE
Issue19 C executable use correct interface

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,6 +52,9 @@ jobs:
         mkdir -p QUIP/build/${QUIP_ARCH}
         cp QUIP/.github/workflows/Makefile.inc QUIP/build/${QUIP_ARCH}/Makefile.inc
         (cd QUIP && make libAtoms)	
+    - name: Build C executable
+      run:
+        make -C libextxyz cextxyz
     - name: Build Fortran executable
       env:
         QUIP_ARCH: linux_x86_64_gfortran

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout repository
@@ -39,7 +39,7 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=.git,QUIP
     - name: Build QUIP/libAtoms
-      env: 
+      env:
         QUIP_ARCH: linux_x86_64_gfortran
         HAVE_GAP: 0
       run: |
@@ -51,7 +51,7 @@ jobs:
         git clone --recursive https://github.com/libAtoms/QUIP QUIP
         mkdir -p QUIP/build/${QUIP_ARCH}
         cp QUIP/.github/workflows/Makefile.inc QUIP/build/${QUIP_ARCH}/Makefile.inc
-        (cd QUIP && make libAtoms)	
+        (cd QUIP && make libAtoms)
     - name: Build C executable
       run:
         make -C libextxyz cextxyz

--- a/libextxyz/test_C_main.c
+++ b/libextxyz/test_C_main.c
@@ -14,7 +14,10 @@ int main(int argc, char *argv[]) {
     int nat;
     DictEntry *info, *arrays;
 
-    int success = extxyz_read_ll(kv_grammar, fp, &nat, &info, &arrays);
+    char comment;
+    char error_message;
+
+    int success = extxyz_read_ll(kv_grammar, fp, &nat, &info, &arrays, &comment, &error_message);
     if (! strcmp(argv[2], "T")) {
         printf("parsed success %d\n", success);
         printf("nat %d\n", nat);


### PR DESCRIPTION
Added arguments to the C executable example uses the correct interface of `extxyz_read_ll`.

Plus I've added CI steps to build the C executable as well, which only serves to check that it can be compiled, and included `python3.12` as a CI job.