### PR TITLE
ci: refresh Python matrix and ASE compat for master

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -10,22 +10,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Checkout submodules
-        run: git submodule update --init --recursive      
+        run: git submodule update --init --recursive
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.1
+        uses: pypa/cibuildwheel@v2.22.0
         env:
-           CIBW_SKIP: cp27-* cp35-* pp* *musl* "*-macosx_arm64"
+           CIBW_SKIP: pp* *musl*
            CIBW_ARCHS_LINUX: "auto64"
-           CIBW_ARCHS_MACOS: "x86_64"
+           CIBW_ARCHS_MACOS: "arm64"
            CIBW_BEFORE_ALL_LINUX: "which yum && yum install -y pcre2-devel zlib-devel"
-           CIBW_TEST_REQUIRES: pytest 
+           CIBW_TEST_REQUIRES: pytest
            CIBW_TEST_COMMAND: "pytest -v {package}/tests"
            
       # # Uncomment to get SSH access for testing
@@ -35,8 +35,9 @@ jobs:
       #   timeout-minutes: 15
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
+          name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
           
       - name: Release wheels
@@ -51,7 +52,7 @@ jobs:
         id: check-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo ::set-output name=match::true
+              echo "match=true" >> $GITHUB_OUTPUT
           fi
     
       - name: Deploy to PyPI

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,15 +16,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Checkout submodules
       run: git submodule update --init --recursive
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies

--- a/python/extxyz/utils.py
+++ b/python/extxyz/utils.py
@@ -1,6 +1,10 @@
 import numpy as np
 
-from ase.constraints import full_3x3_to_voigt_6_stress
+try:
+    from ase.constraints import full_3x3_to_voigt_6_stress
+except ImportError:
+    from ase.stress import full_3x3_to_voigt_6_stress
+
 from ase.calculators.singlepoint import SinglePointCalculator
 
 # partition ase.calculators.calculator.all_properties into two lists:

--- a/tests/test_ase_cases.py
+++ b/tests/test_ase_cases.py
@@ -20,7 +20,10 @@ from ase.build import bulk
 # from ase.calculators.calculator import compare_atoms
 from ase.calculators.emt import EMT
 # from ase.constraints import FixAtoms, FixCartesian
-from ase.constraints import full_3x3_to_voigt_6_stress
+try:
+    from ase.constraints import full_3x3_to_voigt_6_stress
+except ImportError:
+    from ase.stress import full_3x3_to_voigt_6_stress
 from ase.build import molecule
 
 # array data of shape (N, 1) squeezed down to shape (N, ) -- bug fixed


### PR DESCRIPTION
## Summary
- Drop EOL Python from the test matrix (3.7 is gone from runners; 3.8 EOL Oct 2024; 3.9 EOL Oct 2025) and add 3.13.
- Bump `actions/checkout@v2 → @v4` and `actions/setup-python@v2 → @v5` (the v2 versions ride deprecated Node 20).
- Add a try/except import shim for `full_3x3_to_voigt_6_stress` (relocated to `ase.stress` in ASE 3.28+) in `python/extxyz/utils.py` and `tests/test_ase_cases.py`. Same fix as #25.
- **build-wheels.yml**: replace retired runners (ubuntu-20.04 / macos-12 / windows-2019) with the `*-latest` aliases. macos-latest is now arm64-only on hosted runners, so flip `CIBW_ARCHS_MACOS` from `x86_64` to `arm64` and drop the now-redundant `*-macosx_arm64` exclude. Bump `pypa/cibuildwheel 2.12.1 → 2.22.0` (needed for 3.13 support), `actions/checkout@v2 → @v4`, `actions/upload-artifact@v2 → @v4` (v2 is rejected by GitHub now), and replace deprecated `::set-output` with `$GITHUB_OUTPUT`.

Verified locally on macOS arm64 with Python 3.13.13 + ASE 3.28.0: `pytest tests/` → 31 passed, 2 skipped.

Out of scope (deferred — meson branch will land soon and address): the `Build QUIP/libAtoms` step still fails because QUIP no longer ships `Makefile.inc` under `.github/workflows/`. That step's failure is pre-existing and unrelated to the Python-version concern this PR fixes.

## Test plan
- [ ] CI Python 3.10 build green
- [ ] CI Python 3.11 build green
- [ ] CI Python 3.12 build green
- [ ] CI Python 3.13 build green
- [ ] After merge to master: build-wheels run produces wheels on ubuntu-latest, macos-latest, windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)