### PR TITLE
fix(macos): build wheels for macOS 11+ instead of macOS 15+

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -65,7 +65,9 @@ jobs:
            CIBW_ARCHS_LINUX: "auto64"
            CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
            CIBW_ARCHS_MACOS: ${{ matrix.os == 'macos-latest' && 'arm64' || 'x86_64' }}
-           CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=15.0"
+           # macOS deployment target + PCRE2 PKG_CONFIG_PATH live in
+           # [tool.cibuildwheel.macos.environment] in pyproject.toml (a single
+           # CIBW_ENVIRONMENT_MACOS here would replace, not merge with, that table).
            CIBW_ARCHS_WINDOWS: "AMD64"
            
       # Uncomment to get SSH access for testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,16 @@ test-command = "pytest -v {package}/tests"
 before-all = "which yum && yum install -y pcre2-devel zlib-devel"
 
 [tool.cibuildwheel.macos]
-before-all = "brew install pcre2 pkg-config"
+# Build a static PCRE2 from source at MACOSX_DEPLOYMENT_TARGET rather than using the
+# Homebrew bottle (which is compiled for the runner's newest macOS and would make the
+# wheel fail to load on older macOS). meson links it into _extxyz.so via PKG_CONFIG_PATH.
+before-all = "bash {project}/tools/wheels/build_pcre2_macos.sh"
 
 [tool.cibuildwheel.macos.environment]
-PKG_CONFIG_PATH = "/opt/homebrew/lib/pkgconfig:/usr/local/lib/pkgconfig"
+# 11.0 (Big Sur) is the oldest macOS that runs on arm64; build for it so wheels install
+# on all supported macOS. Keep in sync with tools/wheels/build_pcre2_macos.sh.
+MACOSX_DEPLOYMENT_TARGET = "11.0"
+PKG_CONFIG_PATH = "/tmp/pcre2/lib/pkgconfig"
 
 [tool.cibuildwheel.windows]
 before-build = "pip install delvewheel"

--- a/subprojects/pcre2.wrap
+++ b/subprojects/pcre2.wrap
@@ -1,14 +1,16 @@
 [wrap-file]
 directory = pcre2-10.44
-source_url = https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.44/pcre2-10.44.tar.gz
-source_filename = pcre2-10.44.tar.gz
-source_hash = 86b9cb0aa3bcb7994faa88018292bc704cdbb708e785f7c74352ff6ea7d3175b
-patch_filename = pcre2_10.44-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/pcre2_10.44-1/get_patch
-patch_hash = 02c980e9f59b83f7ab2c7e8e02e2b5af11e23733e960f2e9bb531c68e2f04ca1
+source_url = https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.44/pcre2-10.44.tar.bz2
+source_filename = pcre2-10.44.tar.bz2
+source_hash = d34f02e113cf7193a1ebf2770d3ac527088d485d4e047ed10e5d217c6ef5de96
+patch_filename = pcre2_10.44-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/pcre2_10.44-2/get_patch
+patch_hash = 4336d422ee9043847e5e10dbbbd01940d4c9e5027f31ccdc33a7898a1ca94009
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/pcre2_10.44-2/pcre2-10.44.tar.bz2
+wrapdb_version = 10.44-2
 
 [provide]
-libpcre2-8 = libpcre2_8_dep
-libpcre2-16 = libpcre2_16_dep
-libpcre2-32 = libpcre2_32_dep
-libpcre2-posix = libpcre2_posix_dep
+libpcre2-8 = libpcre2_8
+libpcre2-16 = libpcre2_16
+libpcre2-32 = libpcre2_32
+libpcre2-posix = libpcre2_posix

--- a/tools/wheels/build_pcre2_macos.sh
+++ b/tools/wheels/build_pcre2_macos.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Build a static PCRE2 for macOS wheels at the wheel's deployment target.
+#
+# Homebrew's PCRE2 bottle is compiled for the build runner's macOS (e.g. 15.0 or
+# newer), so linking/bundling it produces a wheel that fails to load on older macOS
+# even when the wheel is tagged for an older target. We therefore build PCRE2 from
+# source here, statically, at $MACOSX_DEPLOYMENT_TARGET, and expose it via
+# PKG_CONFIG_PATH (see pyproject.toml). meson then links it into _extxyz.so, so the
+# wheel ships only the extension module with no bundled dylib.
+#
+# Run by cibuildwheel's before-all step on macOS (both arm64 and x86_64).
+set -euo pipefail
+
+PCRE2_VERSION="10.44"   # keep in sync with subprojects/pcre2.wrap
+PREFIX="/tmp/pcre2"
+: "${MACOSX_DEPLOYMENT_TARGET:=11.0}"
+export MACOSX_DEPLOYMENT_TARGET
+
+brew install pkg-config
+
+curl -fL "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${PCRE2_VERSION}/pcre2-${PCRE2_VERSION}.tar.bz2" \
+  -o /tmp/pcre2.tar.bz2
+rm -rf /tmp/pcre2src && mkdir -p /tmp/pcre2src
+tar xjf /tmp/pcre2.tar.bz2 -C /tmp/pcre2src --strip-components=1
+
+cd /tmp/pcre2src
+./configure \
+  --prefix="${PREFIX}" \
+  --enable-static \
+  --disable-shared \
+  --with-pic \
+  --enable-jit \
+  --quiet
+make -j3
+make install


### PR DESCRIPTION
## Problem

Published macOS wheels required **macOS 15+** (`macosx_15_0`), so `pip install extxyz` failed on macOS 11–14 with "no compatible version" / a dyld load error. Reported by a user on macOS arm64 / Python 3.12 installing into a mamba env.

Root cause (verified against the live PyPI wheel): CI set `MACOSX_DEPLOYMENT_TARGET=15.0` **and** bundled Homebrew's PCRE2 bottle (compiled for the runner's macOS), so both `_extxyz.so` and the bundled `libpcre2-8.0.dylib` carried `minos 15.0`. Lowering only the env var is insufficient — the Homebrew dylib stays pinned to the runner's macOS (a real `cibuildwheel` run fails delocation; on a current runner Homebrew PCRE2 is `minos 26.0`).

## Fix

On macOS, build a **static PCRE2 from source** at the wheel's deployment target and link it into `_extxyz.so` (via `PKG_CONFIG_PATH`) instead of bundling Homebrew's bottle.

- `tools/wheels/build_pcre2_macos.sh` — static PCRE2 (JIT + PIC) at `MACOSX_DEPLOYMENT_TARGET`.
- `pyproject.toml` — `before-all` runs the script; `MACOSX_DEPLOYMENT_TARGET=11.0` + `PKG_CONFIG_PATH` in `[tool.cibuildwheel.macos.environment]`.
- `build-wheels.yml` — drop the `CIBW_ENVIRONMENT_MACOS` override (a single env var would *replace*, not merge with, the pyproject environment table, silently dropping `PKG_CONFIG_PATH`).
- `subprojects/pcre2.wrap` — refresh to WrapDB `pcre2_10.44-2`; the pinned `-1` patch hash had gone stale, which had separately broken the meson subproject fallback for source/standalone builds.

## Verification (local cibuildwheel, committed config only)

`cp312-macosx_arm64` → **264 KB** wheel containing only `_extxyz.so`: `minos 11.0`, PCRE2 statically linked (nothing vendored, no `pcre2grep`/headers leaking into user envs), test suite passes during build, installs + imports under Python 3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)