### PR TITLE
perf: drop redundant per-frame array copies; streaming/perf analysis

### DIFF
--- a/python/extxyz/core.py
+++ b/python/extxyz/core.py
@@ -135,23 +135,25 @@ def _read_frame_dict(file, *, use_cextxyz=True, use_regex=True, verbose=0,
                         comment="Properties=species:S:1:pos:R:3")
                 else:
                     raise
-            properties = info.pop('Properties', 'species:S:1:pos:R:3')
-            properties = Properties(property_string=properties)
-            data = np.zeros(natoms, properties.dtype_vector)
-            for name, value in arrays.items():
-                data[name] = value
+            info.pop('Properties', None)
+            # ``read_frame_dicts`` already freed the C buffers, so ``arrays``
+            # are independently-owned numpy arrays in the correct per-column
+            # shapes — use them directly. (Previously these were copied into a
+            # structured array and copied back out again: two redundant copies
+            # per column. The pure-Python path below still needs the structured
+            # ``data`` array produced by np.fromregex/genfromtxt.)
+            arrays_out = arrays
         else:
             natoms, info, data, properties = _read_frame_pure_python(
                 file, verbose=verbose, use_regex=use_regex)
+            # the setter re-views the scalar columns as dtype_vector
+            properties.data = data
+            arrays_out = {name: properties.data[name].copy()
+                          for name in properties.dtype_vector.names}
     except EOFError:
         return None
 
-    properties.data = data
     lattice = extract_lattice(info)
-
-    arrays_out = {name: properties.data[name].copy()
-                  for name in properties.dtype_vector.names}
-
     pbc = np.asarray(info.pop('pbc', [True, True, True]), dtype=bool)
     cell = lattice if lattice is not None else np.zeros((3, 3))
 


### PR DESCRIPTION
## Background — investigating the extxyz-ng performance comparison

The Rust port (`extxyz-ng`) markets ~4× speed and "streaming for large trajectories". I profiled our read path to see what we can actually learn. Two findings reframe the question:

**1. We already match it on streaming / memory.** `iread_dicts` opens the file once and yields one `Frame` at a time; the C `extxyz_read_ll` allocates exactly one frame and frees it right after conversion. Reading an N-frame trajectory holds one frame in memory at a time — constant memory. (extxyz-ng's multi-frame reader, by contrast, desyncs after a few non-trivial frames and can't read a real trajectory at all — see PR #30's benchmark.)

**2. The single-frame gap is the C parser, not Python.** On a 20k-atom frame:

| | time |
|---|---|
| `read_dicts` overall | 7.21 ms |
| C `read_frame_dicts` (parse + convert) | 6.83 ms |
| **Python post-processing** | **0.38 ms (~5%)** |

Controlled experiments isolate the costs further:
- `pos:R:3` only (floats, no strings): **4.74 ms** — already ≈ extxyz-ng's *total* (4.5 ms). The dominant cost is `pcre2_match` per line.
- adding `species:S:1`: **6.93 ms** — the string column adds ~2.2 ms (per-cell `malloc`+`strcpy` in C and per-cell `decode` in Python), vs only ~0.37 ms for an equivalent int column.

## This PR

Removes the only worthwhile Python-side win the profile revealed: `_read_frame_dict` copied each column into a structured array and back out again (two redundant copies). Since `read_frame_dicts` frees the C buffers before returning, the arrays it hands back are already owned — so we use them directly. **~3% faster (7.21 → 6.99 ms) and a simpler code path.** Pure-Python path unchanged.

Verified: core suite (both backends) + ase-extxyz plugin suite green.

## What we are *not* doing (and why)
The remaining levers don't pass the profile's cost/benefit bar pre-release:
- `atof`/`STR_INCR` micro-opts — negligible for typical short numeric fields.
- **String-column cost (~26%)** is the real lever, but cutting it needs a contiguous fixed-width buffer representation in C (so Python can `np.frombuffer` instead of decoding 20k cells in a loop). That touches the C data model, `free_dict`, the writer, the buffer-aliasing path, and `py_to_c_dict` — high blast radius for ~1.5–2 ms.
- Beating `pcre2_match` would mean a hand-rolled per-line tokenizer — a substantial rewrite.

Given we already win on correctness and memory and match streaming, these larger rewrites aren't justified for this release; documenting them here as future options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)