### PR TITLE
fix: parse single-quoted values as backward-compat containers (#5, partial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,9 @@ string of one or more decimal digits, optionally preceded by sign
 
 sequence of one or more of the same primitive type
 *   new style: opens with \[, one or more of the same primitive type separated by commas and optional whitespace, ends with \]
-*   backward compatible: opens with " or \{, one or more of the same primitive types (all types allowed in \{\}, all except string in "")
-    separated by whitespace, ends with matching " or \}.  For backward compatibility, a single element backward 
+*   backward compatible: opens with ", ' or \{, one or more of the same primitive types (all types allowed in \{\}, all except string in "" and '')
+    separated by whitespace, ends with matching ", ' or \}.  Single and double quotes are equivalent
+    containers (ints/floats/bools, no strings).  For backward compatibility, a single element backward
     compatible array is interpreted as a scalar of the same type.
 *   primitive data type is determined by same priority as single primitive item, but must be satisfied
     by entire list simultaneously.  E.g. all integers will result in an integer array, but a mix

--- a/grammar/extxyz_kv_grammar.py
+++ b/grammar/extxyz_kv_grammar.py
@@ -59,7 +59,12 @@ class ExtxyzKVGrammar(Grammar):
     bools_sp = Repeat(Choice(r_true, r_false), mi=1)
     strings_sp = Repeat(r_string, mi=1)
 
+    # Single quotes are a backward-compatible quote container equivalent to
+    # double quotes (the old Fortran/C reader treated ', " and {} alike):
+    # ints/floats/bools only, no strings. (A string-only single-quote
+    # container is a separate, deferred proposal — issue #5.)
     old_one_d_array = Choice(Sequence('"', Choice(ints_sp, ints, floats_sp, floats, bools_sp, bools), '"'),
+                             Sequence("'", Choice(ints_sp, ints, floats_sp, floats, bools_sp, bools), "'"),
                              Sequence('{', Choice(ints_sp, ints, floats_sp, floats, bools_sp, bools, strings_sp, strings), '}'))
 
     one_d_array_i = Sequence('[', ints, ']')

--- a/tests/test_single_quote.py
+++ b/tests/test_single_quote.py
@@ -1,0 +1,57 @@
+"""Single-quoted values must parse as a backward-compatible container,
+equivalent to double quotes (issue #5, parser-only part).
+
+The old Fortran/C reader treated ``'``, ``"`` and ``{}`` equivalently. The new
+implementation had dropped ``'`` support, so real-world files using e.g.
+``pbc='F F F'`` failed (the pure-Python backend raised; the C backend silently
+fell back to defaults). This restores ``'`` as a quote container equivalent to
+``"`` (ints/floats/bools, not strings — the string-only-container proposal is
+deferred). ``'hello'`` therefore stays a bare string.
+"""
+import tempfile
+import os
+
+import numpy as np
+import pytest
+
+from extxyz import read_dicts
+
+
+def _info(line, use_cextxyz, tmp_path):
+    p = tmp_path / "sq.xyz"
+    p.write_text(f"1\nProperties=species:S:1:pos:R:3 {line}\nH 0 0 0\n")
+    return read_dicts(p, use_cextxyz=use_cextxyz)
+
+
+@pytest.mark.parametrize("use_cextxyz", [False, True])
+def test_single_quote_bool_array_pbc(tmp_path, use_cextxyz):
+    """The real-world case from issue #8: pbc='F F F'."""
+    frame = _info("pbc='F F F'", use_cextxyz, tmp_path)
+    assert (frame.pbc == [False, False, False]).all()
+
+
+@pytest.mark.parametrize("use_cextxyz", [False, True])
+def test_single_quote_int_array(tmp_path, use_cextxyz):
+    frame = _info("k='1 2 3'", use_cextxyz, tmp_path)
+    assert np.array_equal(frame.info["k"], [1, 2, 3])
+
+
+@pytest.mark.parametrize("use_cextxyz", [False, True])
+def test_single_quote_scalar(tmp_path, use_cextxyz):
+    """A single-element backward-compat array is a scalar (like \"3\")."""
+    frame = _info("k='3'", use_cextxyz, tmp_path)
+    assert frame.info["k"] == 3
+
+
+@pytest.mark.parametrize("use_cextxyz", [False, True])
+def test_single_quote_equivalent_to_double(tmp_path, use_cextxyz):
+    sq = _info("k='1 2 3'", use_cextxyz, tmp_path)
+    dq = _info('k="1 2 3"', use_cextxyz, tmp_path)
+    assert np.array_equal(sq.info["k"], dq.info["k"])
+
+
+@pytest.mark.parametrize("use_cextxyz", [False, True])
+def test_quoted_word_stays_barestring(tmp_path, use_cextxyz):
+    """'hello' is not numeric/bool, so it remains a bare string (quotes kept)."""
+    frame = _info("k='hello'", use_cextxyz, tmp_path)
+    assert frame.info["k"] == "'hello'"


### PR DESCRIPTION
## What

The old Fortran/C extxyz reader treated `'`, `"` and `{}` as equivalent quote containers, but the new implementation dropped `'` support. Real-world files using e.g. `pbc='F F F'` (see issue #8's example) therefore failed:

- pure-Python backend: `SyntaxError`
- C backend: **silently fell back to defaults** and dropped the value (so `pbc` wrongly became all-true)

This restores `'` as a quote container **equivalent to `"`** — ints/floats/bools, no strings:

| input | result |
|---|---|
| `pbc='F F F'` | `pbc = [F, F, F]` |
| `k='1 2 3'` | int array `[1, 2, 3]` |
| `k='3'` | scalar `3` |
| `k='hello'` | bare string `'hello'` (unchanged — not numeric) |

`'` and `"` now behave identically, on both backends.

## How

One-line grammar change in `grammar/extxyz_kv_grammar.py` (adds a `'…'` `Sequence` to `old_one_d_array`). `python/extxyz/extxyz_kv_grammar.py` is a symlink to it and the C grammar is generated from it, so there's a single source of truth. Both tree walkers (`parse_tree` in `extxyz.c`, the pyleri visitor) dispatch on `OLD_ONE_D_ARRAY` + content type rather than the quote character, so no parser code change was needed. README spec updated.

## Scope

This is the **parser-only** part of #5, per maintainer decision. The larger #5 proposal — a *string-only* single-quote container with writer-side disambiguation so strings that look like arrays round-trip — remains **deferred** (the thread never reached consensus: single-quote-as-string vs `{"…"}`). This PR deliberately does **not** close #5.

## Verification
- New `tests/test_single_quote.py` — 10 cases, both backends.
- Full core suite (30) + ase-extxyz suite (38) green.
- `leaks` clean on a single-quote file; C driver parses `pbc`/`k` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)