### PR TITLE
ci(windows): get pkg-config from vcpkg (pkgconf), not SourceForge

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -37,18 +37,21 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          # Install pkg-config lite (ensures working pkg-config before Strawberry Perl)
-          choco install pkgconfiglite -y
-
-          # Install PCRE2 using vcpkg
-          vcpkg install pcre2:x64-windows
+          # PCRE2 and a pkg-config implementation (pkgconf), both from vcpkg.
+          # The previous `choco install pkgconfiglite` downloaded its binary from
+          # SourceForge, which intermittently 404s and fails the Windows build;
+          # vcpkg's pkgconf has no such external download.
+          vcpkg install pcre2:x64-windows pkgconf:x64-windows
 
           # Set up environment for meson/pkg-config
           VCPKG_ROOT="C:/vcpkg"
           PCRE2_DIR="${VCPKG_ROOT}/installed/x64-windows"
 
-          # Add pkgconfiglite to PATH first (before Strawberry Perl)
-          echo "C:/ProgramData/chocolatey/lib/pkgconfiglite/tools/bin" >> $GITHUB_PATH
+          # Point meson at vcpkg's pkgconf so it can read PCRE2's .pc file.
+          PKGCONF=$(find "${PCRE2_DIR}/tools" -iname 'pkgconf.exe' | head -1)
+          echo "Using pkgconf at: ${PKGCONF}"
+          test -n "${PKGCONF}" || { echo "ERROR: pkgconf.exe not found under ${PCRE2_DIR}/tools"; exit 1; }
+          echo "PKG_CONFIG=${PKGCONF}" >> $GITHUB_ENV
 
           echo "CMAKE_PREFIX_PATH=${PCRE2_DIR}" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=${PCRE2_DIR}/lib/pkgconfig" >> $GITHUB_ENV


### PR DESCRIPTION
## Problem

The Windows wheel build fails intermittently with a SourceForge **404** — but it's not PCRE2. PCRE2 comes from vcpkg (reliable); the SourceForge dependency is the **`choco install pkgconfiglite`** step, whose pkg-config-lite binary is hosted on SourceForge and periodically returns 404:

```
Install PCRE2 via vcpkg (Windows only):
  pkgconfiglite (exited 404) - Error while running chocolateyInstall.ps1
##[error]Process completed with exit code 148.
```

It's only there so meson can read PCRE2's `.pc` file.

## Fix

Install **`pkgconf` from vcpkg** (the same toolchain already used for PCRE2 — no external download) and point meson at it with the `PKG_CONFIG` env var. PCRE2 is still discovered via its vcpkg `.pc` file on `PKG_CONFIG_PATH`, so nothing else changes.

```diff
- choco install pkgconfiglite -y
- vcpkg install pcre2:x64-windows
+ vcpkg install pcre2:x64-windows pkgconf:x64-windows
...
+ PKGCONF=$(find "${PCRE2_DIR}/tools" -iname 'pkgconf.exe' | head -1)
+ echo "PKG_CONFIG=${PKGCONF}" >> $GITHUB_ENV
```

The pkgconf path is located with `find` (with a hard failure if absent) rather than hard-coded, in case the vcpkg layout shifts. Only `build-wheels.yml` used `pkgconfiglite`.

The proof is the Windows wheel jobs going green here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)