### PR TITLE
Make the whitespace tokenizer the default read mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,14 @@ with `strtod`, falling back to `strtod` for exponents or higher
 precision). Together these are worth ~40% on a 200k-atom read (the
 float fast path alone ~1.4×).
 
-### Opt-in tokenizer (`use_regex=False`)
+### Default tokenizer (`use_regex=False`)
 
-The single biggest remaining cost is the per-line `pcre2_match`. Passing
-`use_regex=False` to `read_dicts`/`iread_dicts` (C backend only) skips it: the
+The single biggest remaining cost is the per-line `pcre2_match`. The default
+`use_regex=False` in `read_dicts`/`iread_dicts` (C backend only) skips it: the
 per-atom lines are split on whitespace and each field is parsed and validated by
-its column type, with no regex compile or match. It is **opt-in and off by
-default**, and a further **~1.5×** on top of everything above:
+its column type, with no regex compile or match. It is **the default since
+v0.4.2** (pass `use_regex=True` for the strict regex parser), and a further
+**~1.5×** on top of everything above:
 
 | atoms / frame | `read_dicts` (regex) | `read_dicts` (`use_regex=False`) | tokenizer / regex | tokenizer / built-in |
 |--:|--:|--:|--:|--:|
@@ -108,8 +109,8 @@ default**, and a further **~1.5×** on top of everything above:
 It validates each field (a malformed numeric/bool or the wrong field count is a
 clear parse error, not a silent `0`) and is bit-identical to the regex parser on
 valid input. The trade-off is that it is marginally more lenient than the grammar
-on a few numeric edge cases (e.g. leading-zero integers `007`, `1.`/`.5`), which
-is why it is opt-in rather than the default.
+on a few numeric edge cases (e.g. leading-zero integers `007`, `1.`/`.5`); pass
+`use_regex=True` if you need the grammar enforced exactly.
 
 The big parser-side lever was PCRE2 JIT (`pcre2_jit_compile(re,
 PCRE2_JIT_COMPLETE)` after `pcre2_compile`); a `sample`-based profile
@@ -235,7 +236,8 @@ extxyz.write_dicts("newfile.xyz", frame)
 
 `index` accepts an int, a `slice`, or `':'` (negative indices are not
 supported). Pass `use_cextxyz=False` for the pure-Python parser, or
-`use_regex=False` (C backend) for the faster opt-in tokenizer.
+`use_regex=True` (C backend) for the strict regex parser instead of the
+default whitespace tokenizer.
 
 ## With ASE — the `ase-extxyz` plugin
 

--- a/python/extxyz/cextxyz.py
+++ b/python/extxyz/cextxyz.py
@@ -283,17 +283,17 @@ def cfseek(fp, offset, whence):
     return _fseek(fp, offset, whence)
 
 
-def read_frame_dicts(fp, verbose=False, comment=None, use_regex=True):
+def read_frame_dicts(fp, verbose=False, comment=None, use_regex=False):
     """Read a single frame using extxyz_read_ll_opts() C function
 
     Args:
         fp (FILE_ptr): open file pointer, as returned by `cfopen()`
         verbose (bool, optional): Dump C dictionaries to stdout. Defaults to False.
         comment (str, optional): Overrride comment line with specified string.
-        use_regex (bool, optional): parse per-atom lines with the PCRE2 regex
-            (default). If False, use the faster whitespace tokenizer (validates
-            each field; marginally more lenient than the grammar on numeric
-            edge cases).
+        use_regex (bool, optional): if False (default), parse per-atom lines
+            with the fast whitespace tokenizer, which validates each field.
+            If True, use the slower PCRE2 regex parser instead (marginally
+            stricter than the tokenizer on numeric edge cases).
 
     Returns:
         nat, info, arrays: int, dict, dict

--- a/python/extxyz/core.py
+++ b/python/extxyz/core.py
@@ -81,7 +81,7 @@ def read_comment_line(line, verbose=0):
     return result_to_dict(result, verbose=verbose)
 
 
-def _read_frame_pure_python(file, verbose=0, use_regex=True):
+def _read_frame_pure_python(file, verbose=0, use_regex=False):
     """Read one extxyz frame from ``file`` using the pure-Python path.
 
     Returns ``(natoms, info_dict, structured_data, properties)``.
@@ -117,7 +117,7 @@ def _read_frame_pure_python(file, verbose=0, use_regex=True):
     return natoms, info, data, properties
 
 
-def _read_frame_dict(file, *, use_cextxyz=True, use_regex=True, verbose=0,
+def _read_frame_dict(file, *, use_cextxyz=True, use_regex=False, verbose=0,
                     comment=None) -> Frame | None:
     """Read one frame and return a :class:`Frame`, or ``None`` past EOF."""
     try:
@@ -162,7 +162,7 @@ def _read_frame_dict(file, *, use_cextxyz=True, use_regex=True, verbose=0,
 
 
 def iread_dicts(file, index=None, *,
-                use_cextxyz=True, use_regex=True, verbose=0, comment=None
+                use_cextxyz=True, use_regex=False, verbose=0, comment=None
                 ) -> Iterator[Frame]:
     """Yield :class:`Frame` instances from ``file`` lazily.
 

--- a/tests/test_fast_tokenizer.py
+++ b/tests/test_fast_tokenizer.py
@@ -1,6 +1,6 @@
-"""The opt-in tokenizer read mode (use_regex=False on the C backend).
+"""The tokenizer read mode (use_regex=False on the C backend, the default).
 
-It must (a) produce bit-identical results to the default regex parser for valid
+It must (a) produce bit-identical results to the strict regex parser for valid
 files, and (b) reject malformed per-atom fields with a clear error instead of
 silently mis-parsing (which atoi/atof would do).
 """
@@ -74,10 +74,19 @@ def test_tokenizer_rejects_malformed(tmp_path, body):
         read_dicts(p, use_cextxyz=True, use_regex=False)
 
 
-def test_regex_mode_unchanged_is_default(tmp_path):
-    """use_regex defaults to True; malformed numerics that the tokenizer rejects
-    are also rejected by the regex (NOMATCH)."""
-    p = tmp_path / "bad.xyz"
-    p.write_text("1\nProperties=species:S:1:pos:R:3\nH NOTANUM 0 0\n")
+def test_tokenizer_is_default(tmp_path):
+    """use_regex defaults to False (tokenizer) since v0.4.2: a default read
+    matches an explicit use_regex=False read, and malformed numerics are
+    still rejected."""
+    good = tmp_path / "good.xyz"
+    good.write_text('1\nLattice="3 0 0 0 3 0 0 0 3" Properties=species:S:1:pos:R:3\n'
+                    'H 0.1 0.2 0.3\n')
+    default = read_dicts(good, use_cextxyz=True)
+    fast = read_dicts(good, use_cextxyz=True, use_regex=False)
+    assert default.arrays.keys() == fast.arrays.keys()
+    assert np.array_equal(default.arrays['pos'], fast.arrays['pos'])
+
+    bad = tmp_path / "bad.xyz"
+    bad.write_text("1\nProperties=species:S:1:pos:R:3\nH NOTANUM 0 0\n")
     with pytest.raises(cextxyz.ExtXYZError):
-        read_dicts(p, use_cextxyz=True)   # default regex
+        read_dicts(bad, use_cextxyz=True)   # default tokenizer


### PR DESCRIPTION
Flips `use_regex` to default `False` in `read_dicts`/`iread_dicts` (C backend and pure-Python path), so the fast whitespace tokenizer is the default everywhere. This makes all the bindings consistent: the `ase-extxyz` plugin already defaulted to the tokenizer, and ExtXYZ.jl 0.4.0 will default to it too.

- The strict PCRE2 regex parser remains available with `use_regex=True`.
- The tokenizer is ~1.5x faster, validates every field (malformed numerics/bools and wrong field counts are clear parse errors), and is bit-identical to the regex parser on valid input; it is only marginally more lenient on numeric edge cases (`007`, `1.`, `.5`).
- `test_regex_mode_unchanged_is_default` is replaced by `test_tokenizer_is_default`, pinning the new default; README updated.

Full test suite passes (64 passed, 2 skipped). Intended for the v0.4.2 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)