### PR TITLE
perf: marshal the C read path's dicts in C (numpy C-API), ~1.5x reads

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,6 +43,10 @@ jobs:
         # to satisfy that from PyPI (where 0.3.0 isn't published yet).
         python -m pip install . --verbose
         python -m pip install --no-deps ./python/ase-extxyz
+    - name: Assert C-API fast read path is active
+      # numpy is a build-time dependency, so a source build must produce the
+      # C-API read path; fail loudly if it silently fell back to ctypes.
+      run: python tools/assert_c_read_path.py
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ extxyz.egg-info/
 *.o
 pcre2-10.37/
 venv/
+.venv*/
+
+# Large benchmark inputs / derived files (never commit)
+/mad-train.xyz
+/scope_e*.xyz
 
 # Claude notes (don't commit)
 MESON_BUILD_STATUS.md

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The latest development version can be installed via
 pip install git+https://github.com/libAtoms/extxyz
 ```
 
-This requires Python 3.10+ and a working C compiler, plus the PCRE2 and libcleri libraries. `libcleri` is included here as a submodule and will be compiled automatically, but you may need to install PCRE2 with something similar to one of the following commands.
+This requires Python 3.10+ and a working C compiler, plus the PCRE2 and libcleri libraries. `libcleri` is included here as a submodule and will be compiled automatically, but you may need to install PCRE2 with something similar to one of the following commands. NumPy is also needed at build time (it is already a runtime dependency): its C headers build the `_extxyz` extension's fast read path. A build without NumPy headers still works — it falls back to the slower ctypes read path.
 
 ```
 brew install pcre2          # macOS with Homebrew
@@ -111,6 +111,21 @@ clear parse error, not a silent `0`) and is bit-identical to the regex parser on
 valid input. The trade-off is that it is marginally more lenient than the grammar
 on a few numeric edge cases (e.g. leading-zero integers `007`, `1.`/`.5`); pass
 `use_regex=True` if you need the grammar enforced exactly.
+
+### Marshalling in C
+
+Once the C reader has parsed a frame it has to hand the `info`/`arrays` data
+back to Python. This is done inside the `_extxyz` extension (numpy C-API):
+each frame's dict of scalars and numpy arrays is built directly in C, rather
+than walking the C linked list one field at a time through `ctypes`. It is
+bit-identical to the previous path (and falls back to it automatically if the
+extension was built without numpy). The win is per-frame, so it matters most on
+files with **many small frames** and/or **rich comment lines**, where per-frame
+overhead — not per-atom parsing — dominates. On the large single-frame Cu
+benchmark above the effect is small; on a 76k-frame, ~27-atom-per-frame training
+set it cut the dict-level parse from ~3.6&nbsp;s to ~2.3&nbsp;s (~1.5×) and the
+full ASE read from ~4.8&nbsp;s to ~3.3&nbsp;s, removing essentially all of the
+former per-field `ctypes` cost.
 
 The big parser-side lever was PCRE2 JIT (`pcre2_jit_compile(re,
 PCRE2_JIT_COMPLETE)` after `pcre2_compile`); a `sample`-based profile

--- a/benchmarks/bench_mad.py
+++ b/benchmarks/bench_mad.py
@@ -1,0 +1,62 @@
+"""Reproduce the chemfiles-author MAD benchmark and quantify the
+regex -> whitespace-tokenizer speedup for our C parser.
+
+Usage: python benchmarks/bench_mad.py [path-to-mad-train.xyz] [n_iter]
+"""
+import sys
+import time
+
+import ase.io
+import ase_extxyz.io  # noqa: F401  registers format='cextxyz'
+from chemfiles import Trajectory
+
+filename = sys.argv[1] if len(sys.argv) > 1 else "mad-train.xyz"
+n_iter = int(sys.argv[2]) if len(sys.argv) > 2 else 3
+
+
+def best_of(fn, n):
+    best = float("inf")
+    last = None
+    for _ in range(n):
+        t0 = time.perf_counter()
+        last = fn()
+        dt = time.perf_counter() - t0
+        best = min(best, dt)
+    return best, last
+
+
+def read_chemfiles():
+    traj = Trajectory(filename)
+    frames = [traj.read_step(i) for i in range(traj.nsteps)]
+    return frames
+
+
+# warm FS cache
+n0 = len(ase.io.read(filename, format="cextxyz", index=":"))
+print(f"frames: {n0}\n")
+
+configs = [
+    ("cextxyz (tokenizer, use_regex=False)",
+     lambda: ase.io.read(filename, format="cextxyz", index=":", use_regex=False)),
+    ("cextxyz (regex,     use_regex=True )",
+     lambda: ase.io.read(filename, format="cextxyz", index=":", use_regex=True)),
+    ("extxyz  (ASE built-in)",
+     lambda: ase.io.read(filename, format="extxyz", index=":")),
+    ("chemfiles",
+     read_chemfiles),
+]
+
+results = {}
+for name, fn in configs:
+    dt, out = best_of(fn, n_iter)
+    results[name] = dt
+    print(f"{name:42s} {dt:6.2f}s  ({len(out)} frames)")
+
+print()
+tok = results["cextxyz (tokenizer, use_regex=False)"]
+rgx = results["cextxyz (regex,     use_regex=True )"]
+print(f"our tokenizer vs our regex:  {rgx/tok:.2f}x faster "
+      f"({rgx:.2f}s -> {tok:.2f}s)")
+print(f"our tokenizer vs ASE builtin: "
+      f"{results['extxyz  (ASE built-in)']/tok:.2f}x faster")
+print(f"chemfiles vs our tokenizer:  {tok/results['chemfiles']:.2f}x faster")

--- a/benchmarks/scope_comment.py
+++ b/benchmarks/scope_comment.py
@@ -1,0 +1,114 @@
+"""Scope the comment-line (libcleri) grammar cost in the C read path.
+
+Builds derived files (pure text, no parsing) that hold the per-frame count
+fixed at the real value but vary the work, then times extxyz.read_dicts
+(dict level — no ASE conversion) on each:
+
+  E0 real          : grammar(6 keys) + marshal + tokenize(~27 atoms)   [baseline]
+  E1 real, 1 atom  : grammar(6 keys) + marshal + tokenize(1 atom)      [comment path only]
+  E2 min,  1 atom  : grammar(2 keys) + marshal + tokenize(1 atom)      [minimal comment]
+  E3 rebundled x8  : 1/8 the frames, same atom lines                   [per-frame overhead]
+
+Deltas:
+  E0 - E1  ~= per-atom tokenizer cost for ~26 atoms (the part use_regex toggles)
+  E1 - E2  ~= marginal grammar+marshal cost of the 4 extra info keys
+  E0 - E3  ~= total per-frame overhead removed by 8x bigger frames
+"""
+import sys, time
+import extxyz
+
+SRC = sys.argv[1] if len(sys.argv) > 1 else "mad-train.xyz"
+NIT = int(sys.argv[2]) if len(sys.argv) > 2 else 3
+
+REAL_COMMENT = None
+PROPS_LATT = None  # minimal: Properties + Lattice only
+
+
+def split_frames(path):
+    """Yield (natoms:int, comment:str, atom_lines:list[str]) streaming."""
+    with open(path) as f:
+        while True:
+            head = f.readline()
+            if not head:
+                return
+            nat = int(head)
+            comment = f.readline()
+            atoms = [f.readline() for _ in range(nat)]
+            yield nat, comment, atoms
+
+
+def build_derived():
+    global REAL_COMMENT, PROPS_LATT
+    f_e1 = open("scope_e1_0atom_real.xyz", "w")
+    f_e2 = open("scope_e2_0atom_min.xyz", "w")
+    f_e3 = open("scope_e3_rebundle8.xyz", "w")
+    buf_nat, buf_lines, buf_comment, group = 0, [], None, 0
+    K = 8
+    for nat, comment, atoms in split_frames(SRC):
+        if REAL_COMMENT is None:
+            REAL_COMMENT = comment
+            toks = comment.split()
+            # keep Properties=... and Lattice="..." (Lattice spans quotes)
+            props = next(t for t in toks if t.startswith("Properties="))
+            li = comment.index('Lattice="')
+            latt = comment[li:comment.index('"', li + 9) + 1]
+            PROPS_LATT = f"{props} {latt}\n"
+        # E1: 1-atom frames with the real comment (1 atom = minimal tokenizer work)
+        f_e1.write("1\n")
+        f_e1.write(REAL_COMMENT)
+        f_e1.write(atoms[0])
+        # E2: 1-atom frames with minimal comment
+        f_e2.write("1\n")
+        f_e2.write(PROPS_LATT)
+        f_e2.write(atoms[0])
+        # E3: rebundle K frames into one (reuse this group's first comment)
+        if group == 0:
+            buf_comment = comment
+        buf_lines.extend(atoms)
+        buf_nat += nat
+        group += 1
+        if group == K:
+            f_e3.write(f"{buf_nat}\n")
+            f_e3.write(buf_comment)
+            f_e3.writelines(buf_lines)
+            buf_nat, buf_lines, buf_comment, group = 0, [], None, 0
+    if group:
+        f_e3.write(f"{buf_nat}\n")
+        f_e3.write(buf_comment)
+        f_e3.writelines(buf_lines)
+    f_e1.close(); f_e2.close(); f_e3.close()
+
+
+def timeit(path, n=NIT):
+    best = float("inf"); nframes = 0
+    for _ in range(n):
+        t0 = time.perf_counter()
+        out = extxyz.read_dicts(path, use_regex=False)
+        best = min(best, time.perf_counter() - t0)
+        nframes = len(out)
+    return best, nframes
+
+
+build_derived()
+cases = [
+    ("E0 real (baseline)",        SRC),
+    ("E1 real comment, 1 atom",   "scope_e1_0atom_real.xyz"),
+    ("E2 min comment,  1 atom",   "scope_e2_0atom_min.xyz"),
+    ("E3 rebundled x8",           "scope_e3_rebundle8.xyz"),
+]
+res = {}
+for name, path in cases:
+    dt, nf = timeit(path)
+    res[name] = (dt, nf)
+    print(f"{name:28s} {dt:6.2f}s  ({nf} frames)")
+
+e0 = res["E0 real (baseline)"][0]
+e1 = res["E1 real comment, 1 atom"][0]
+e2 = res["E2 min comment,  1 atom"][0]
+e3 = res["E3 rebundled x8"][0]
+print()
+print(f"per-atom tokenizer cost  (E0-E1): {e0-e1:5.2f}s  ({100*(e0-e1)/e0:4.0f}% of read)")
+print(f"comment path total       (E1)   : {e1:5.2f}s  ({100*e1/e0:4.0f}% of read)")
+print(f"  of which 4 extra keys (E1-E2) : {e1-e2:5.2f}s")
+print(f"  minimal comment+marshal (E2)  : {e2:5.2f}s")
+print(f"per-frame overhead via rebundle (E0-E3): {e0-e3:5.2f}s  (E3={e3:.2f}s)")

--- a/benchmarks/verify_marshal.py
+++ b/benchmarks/verify_marshal.py
@@ -1,0 +1,73 @@
+"""Assert the C-API marshalling (_extxyz.read_frame) is byte-identical to the
+legacy ctypes marshalling (c_to_py_dict), frame by frame.
+
+Flips cextxyz._USE_LEGACY_MARSHAL in-process (the dispatcher reads it per call).
+"""
+import sys
+import numpy as np
+import extxyz
+from extxyz import cextxyz
+
+path = sys.argv[1] if len(sys.argv) > 1 else "mad-train.xyz"
+
+assert cextxyz._HAVE_C_READ, "C read path not built — rebuild with numpy"
+
+
+def read_all(legacy):
+    cextxyz._USE_LEGACY_MARSHAL = legacy
+    return extxyz.read_dicts(path)
+
+
+new = read_all(False)
+old = read_all(True)
+cextxyz._USE_LEGACY_MARSHAL = False
+
+assert len(new) == len(old), f"frame count {len(new)} != {len(old)}"
+print(f"comparing {len(new)} frames ...")
+
+bad = 0
+for i, (a, b) in enumerate(zip(new, old)):
+    def fail(msg):
+        global bad
+        bad += 1
+        if bad <= 20:
+            print(f"  frame {i}: {msg}")
+
+    if a.natoms != b.natoms:
+        fail(f"natoms {a.natoms} != {b.natoms}"); continue
+    if not np.array_equal(a.cell.view('u8'), b.cell.view('u8')):
+        fail("cell differs")
+    if (a.pbc != b.pbc).any():
+        fail("pbc differs")
+    # info dict
+    if set(a.info) != set(b.info):
+        fail(f"info keys {set(a.info)} != {set(b.info)}"); continue
+    for k in a.info:
+        va, vb = a.info[k], b.info[k]
+        if isinstance(va, np.ndarray) or isinstance(vb, np.ndarray):
+            va, vb = np.asarray(va), np.asarray(vb)
+            if va.shape != vb.shape or va.dtype != vb.dtype:
+                fail(f"info[{k!r}] dtype/shape {va.dtype}{va.shape} != {vb.dtype}{vb.shape}")
+            elif va.dtype.kind == 'f':
+                if not np.array_equal(va.view('u8'), vb.view('u8')):
+                    fail(f"info[{k!r}] float bits differ")
+            elif not np.array_equal(va, vb):
+                fail(f"info[{k!r}] differs")
+        else:
+            if type(va) is not type(vb) or va != vb:
+                fail(f"info[{k!r}] {va!r} ({type(va).__name__}) != {vb!r} ({type(vb).__name__})")
+    # arrays dict
+    if set(a.arrays) != set(b.arrays):
+        fail(f"arrays keys {set(a.arrays)} != {set(b.arrays)}"); continue
+    for k in a.arrays:
+        va, vb = a.arrays[k], b.arrays[k]
+        if va.dtype != vb.dtype or va.shape != vb.shape:
+            fail(f"arrays[{k!r}] dtype/shape {va.dtype}{va.shape} != {vb.dtype}{vb.shape}")
+        elif va.dtype.kind == 'f':
+            if not np.array_equal(va.view('u8'), vb.view('u8')):
+                fail(f"arrays[{k!r}] float bits differ")
+        elif not np.array_equal(va, vb):
+            fail(f"arrays[{k!r}] differs")
+
+print(f"DONE: {len(new)} frames, mismatches = {bad}")
+sys.exit(1 if bad else 0)

--- a/libextxyz/_extxyz_pyext.def
+++ b/libextxyz/_extxyz_pyext.def
@@ -1,0 +1,18 @@
+; MSVC exports for the _extxyz extension when built WITH the C-API fast read
+; path (libextxyz/pyext.c, i.e. numpy available). Same ctypes-loaded symbols as
+; _extxyz.def plus PyInit__extxyz so `import extxyz._extxyz` works on Windows.
+; Keep in sync with _extxyz.def (the numpy-less variant).
+EXPORTS
+    PyInit__extxyz
+    compile_extxyz_kv_grammar
+    cleri_grammar_free
+    extxyz_read_ll
+    extxyz_read_ll_opts
+    extxyz_write_ll
+    extxyz_write_ll_fmt
+    print_dict
+    free_dict
+    extxyz_fopen
+    extxyz_fclose
+    extxyz_ftell
+    extxyz_fseek

--- a/libextxyz/meson.build
+++ b/libextxyz/meson.build
@@ -10,14 +10,32 @@ run_command(
 # Build and install the extension module
 extxyz_c_sources = ['extxyz.c', 'extxyz_kv_grammar.c', 'fast_format.c']
 
-# Python extension (loaded by cextxyz.py via ctypes.CDLL)
+# The _extxyz extension is loaded both via ctypes.CDLL (for write/grammar/stdio)
+# and — when built with numpy — imported as a real C-API module for the fast
+# read path (pyext.c provides PyInit__extxyz + read_frame). pyext.c is added
+# ONLY here, never to the standalone shared library or the C/Fortran drivers.
+extxyz_ext_sources = extxyz_c_sources
+extxyz_ext_cargs = []
+# MSVC exports are pinned by a .def; the numpy build adds PyInit__extxyz so the
+# module is importable on Windows, the numpy-less build must NOT list it (the
+# symbol doesn't exist then -> link error).
+extxyz_ext_def = '_extxyz.def'
+if have_numpy
+    extxyz_ext_sources += ['pyext.c']
+    extxyz_ext_cargs += [numpy_inc_arg]
+    extxyz_ext_def = '_extxyz_pyext.def'
+endif
+
+# Python extension (loaded by cextxyz.py via ctypes.CDLL, and imported when
+# built with the C-API fast read path)
 module = python.extension_module(
     '_extxyz',
-    extxyz_c_sources,
+    extxyz_ext_sources,
     install: true,
     subdir: 'extxyz',
+    c_args: extxyz_ext_cargs,
     gnu_symbol_visibility: 'default', # keep symbols public on GCC/Clang
-    vs_module_defs: '_extxyz.def',    # explicit exports for MSVC (loaded via ctypes)
+    vs_module_defs: extxyz_ext_def,   # explicit exports for MSVC (loaded via ctypes)
     dependencies: [cleri, pcre2]
 )
 

--- a/libextxyz/pyext.c
+++ b/libextxyz/pyext.c
@@ -1,0 +1,251 @@
+/* CPython C-API entry point for the fast read path.
+ *
+ * This translation unit is compiled ONLY into the `_extxyz` Python extension
+ * module (see libextxyz/meson.build) — never into the standalone libextxyz
+ * shared library or the C/Fortran test drivers, which must stay free of any
+ * Python/numpy dependency. It calls the unchanged C core (extxyz_read_ll_opts)
+ * and marshals the resulting DictEntry linked lists straight into Python
+ * dicts of numpy arrays / scalars, replacing the former per-node ctypes loop
+ * in cextxyz.py (c_to_py_dict).
+ *
+ * The marshalling here must stay byte-for-byte equivalent to c_to_py_dict;
+ * benchmarks/verify_marshal.py checks new-vs-legacy output on real data.
+ */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <cleri/cleri.h>
+#include "extxyz.h"
+
+/* Module-level exception, mirrors cextxyz.ExtXYZError. */
+static PyObject *ExtXYZError = NULL;
+
+/* Build the Python value for one DictEntry node. Returns a new reference, or
+ * NULL with a Python exception set. Mirrors c_to_py_dict() exactly. */
+static PyObject *node_to_value(DictEntry *node)
+{
+    const enum data_type t = node->data_t;
+    const int nrows = node->nrows;
+    const int ncols = node->ncols;
+
+    /* ---- scalar ---- */
+    if (nrows == 0 && ncols == 0) {
+        switch (t) {
+        case data_i:
+            return PyLong_FromLong(*(int *)node->data);
+        case data_f:
+            return PyFloat_FromDouble(*(double *)node->data);
+        case data_b:
+            return PyBool_FromLong(*(int *)node->data);
+        case data_s:
+            return PyUnicode_FromString(*(char **)node->data);
+        default:
+            PyErr_Format(ExtXYZError, "unsupported scalar data type %d", (int)t);
+            return NULL;
+        }
+    }
+
+    /* ---- array (vector or matrix) ---- */
+    const int is_matrix = (nrows > 0);
+    npy_intp dims[2];
+    int ndim;
+    npy_intp n;
+    if (is_matrix) {
+        ndim = 2;
+        dims[0] = nrows;
+        dims[1] = ncols;
+        n = (npy_intp)nrows * (npy_intp)ncols;
+    } else {
+        ndim = 1;
+        dims[0] = ncols;
+        n = ncols;
+    }
+
+    if (t == data_i || t == data_f || t == data_b) {
+        /* dtypes chosen to match the legacy np.ctypeslib.as_array output:
+         * int -> int32, double -> float64, bool -> (int32 then astype bool). */
+        if (t == data_f) {
+            PyObject *arr = PyArray_SimpleNew(ndim, dims, NPY_FLOAT64);
+            if (!arr) return NULL;
+            memcpy(PyArray_DATA((PyArrayObject *)arr), node->data,
+                   (size_t)n * sizeof(double));
+            return arr;
+        }
+        if (t == data_i) {
+            PyObject *arr = PyArray_SimpleNew(ndim, dims, NPY_INT32);
+            if (!arr) return NULL;
+            memcpy(PyArray_DATA((PyArrayObject *)arr), node->data,
+                   (size_t)n * sizeof(int32_t));
+            return arr;
+        }
+        /* data_b: C stores int (0/1); legacy produced a NPY_BOOL array. */
+        PyObject *arr = PyArray_SimpleNew(ndim, dims, NPY_BOOL);
+        if (!arr) return NULL;
+        const int *src = (const int *)node->data;
+        npy_bool *dst = (npy_bool *)PyArray_DATA((PyArrayObject *)arr);
+        for (npy_intp i = 0; i < n; i++)
+            dst[i] = src[i] ? 1 : 0;
+        return arr;
+    }
+
+    if (t == data_s) {
+        if (node->n_in_row < 0) {
+            /* contiguous fixed-width buffer: width = -n_in_row bytes/cell.
+             * Mirror _read_contiguous_strings: frombuffer('S{w}').astype(str)
+             * => fixed-width NPY_UNICODE ('U{w}'), trailing nulls dropped. */
+            const int width = -node->n_in_row;
+            npy_intp uni_dims[2];
+            for (int d = 0; d < ndim; d++) uni_dims[d] = dims[d];
+            PyObject *arr = PyArray_New(&PyArray_Type, ndim, uni_dims,
+                                        NPY_UNICODE, NULL, NULL,
+                                        width * 4 /* UCS4 itemsize */, 0, NULL);
+            if (!arr) return NULL;
+            const unsigned char *base = (const unsigned char *)node->data;
+            char *out = (char *)PyArray_DATA((PyArrayObject *)arr);
+            memset(out, 0, (size_t)n * (size_t)width * 4);
+            for (npy_intp i = 0; i < n; i++) {
+                const unsigned char *cell = base + (size_t)i * (size_t)width;
+                Py_UCS4 *d = (Py_UCS4 *)(out + (size_t)i * (size_t)width * 4);
+                for (int c = 0; c < width; c++) {
+                    if (cell[c] == 0) break;
+                    d[c] = (Py_UCS4)cell[c];
+                }
+            }
+            return arr;
+        }
+        /* scattered char**: decode each into a Python list, let numpy infer the
+         * 'U{maxlen}' dtype exactly as np.array([...]) did. Rare, not hot. */
+        PyObject *list = PyList_New(n);
+        if (!list) return NULL;
+        char **src = (char **)node->data;
+        for (npy_intp i = 0; i < n; i++) {
+            PyObject *s = PyUnicode_FromString(src[i]);
+            if (!s) { Py_DECREF(list); return NULL; }
+            PyList_SET_ITEM(list, i, s); /* steals ref */
+        }
+        PyObject *flat = PyArray_FromAny(list, NULL, 0, 0,
+                                         NPY_ARRAY_DEFAULT, NULL);
+        Py_DECREF(list);
+        if (!flat) return NULL;
+        if (is_matrix) {
+            PyArray_Dims shape = { dims, ndim };
+            PyObject *reshaped = PyArray_Newshape((PyArrayObject *)flat, &shape,
+                                                  NPY_CORDER);
+            Py_DECREF(flat);
+            return reshaped;
+        }
+        return flat;
+    }
+
+    PyErr_Format(ExtXYZError, "unsupported data type %d", (int)t);
+    return NULL;
+}
+
+/* Convert a DictEntry linked list to a new Python dict, or NULL on error. */
+static PyObject *dict_to_py(DictEntry *head)
+{
+    PyObject *result = PyDict_New();
+    if (!result) return NULL;
+    for (DictEntry *node = head; node; node = node->next) {
+        PyObject *value = node_to_value(node);
+        if (!value) { Py_DECREF(result); return NULL; }
+        if (PyDict_SetItemString(result, node->key, value) != 0) {
+            Py_DECREF(value);
+            Py_DECREF(result);
+            return NULL;
+        }
+        Py_DECREF(value);
+    }
+    return result;
+}
+
+/* read_frame(grammar_addr:int, fp_addr:int, use_tokenizer:int,
+ *            comment:str|None=None) -> (nat:int, info:dict, arrays:dict)
+ * Raises EOFError at end of file, ExtXYZError on a parse error. */
+static PyObject *py_read_frame(PyObject *self, PyObject *args)
+{
+    (void)self;
+    unsigned long long grammar_addr, fp_addr;
+    int use_tokenizer;
+    const char *comment = NULL;
+    if (!PyArg_ParseTuple(args, "KKi|z", &grammar_addr, &fp_addr,
+                          &use_tokenizer, &comment))
+        return NULL;
+
+    cleri_grammar_t *grammar = (cleri_grammar_t *)(uintptr_t)grammar_addr;
+    FILE *fp = (FILE *)(uintptr_t)fp_addr;
+
+    int nat = 0;
+    DictEntry *info = NULL, *arrays = NULL;
+    char error_message[1024];
+    error_message[0] = '\0';
+
+    int ok;
+    Py_BEGIN_ALLOW_THREADS
+    ok = extxyz_read_ll_opts(grammar, fp, &nat, &info, &arrays,
+                             (char *)comment, error_message, use_tokenizer);
+    Py_END_ALLOW_THREADS
+
+    if (!ok) {
+        /* Mirror the EOF heuristic in cextxyz.read_frame_dicts. */
+        if (error_message[0] == '\0' ||
+            strncmp(error_message,
+                    "Failed to parse int natoms from ' ", 34) == 0) {
+            PyErr_SetNone(PyExc_EOFError);
+        } else {
+            /* Raw message; the Python wrapper normalises it (.strip().replace)
+             * to stay byte-identical with the legacy ctypes path. */
+            PyErr_SetString(ExtXYZError, error_message);
+        }
+        /* info/arrays are not owned by us on failure (see cextxyz.py). */
+        return NULL;
+    }
+
+    PyObject *py_info = dict_to_py(info);
+    PyObject *py_arrays = py_info ? dict_to_py(arrays) : NULL;
+
+    free_dict(info);
+    free_dict(arrays);
+
+    if (!py_info || !py_arrays) {
+        Py_XDECREF(py_info);
+        Py_XDECREF(py_arrays);
+        return NULL;
+    }
+    return Py_BuildValue("(iNN)", nat, py_info, py_arrays);
+}
+
+static PyMethodDef extxyz_methods[] = {
+    {"read_frame", py_read_frame, METH_VARARGS,
+     "read_frame(grammar_addr, fp_addr, use_tokenizer, comment=None) -> "
+     "(nat, info, arrays). Reads and marshals one frame in C."},
+    {NULL, NULL, 0, NULL},
+};
+
+static struct PyModuleDef extxyz_module = {
+    PyModuleDef_HEAD_INIT, "_extxyz",
+    "C-API fast read path for extxyz (additive to the ctypes interface).",
+    -1, extxyz_methods, NULL, NULL, NULL, NULL,
+};
+
+PyMODINIT_FUNC PyInit__extxyz(void)
+{
+    import_array();
+    PyObject *m = PyModule_Create(&extxyz_module);
+    if (!m) return NULL;
+    ExtXYZError = PyErr_NewException("_extxyz.ExtXYZError", NULL, NULL);
+    if (!ExtXYZError) { Py_DECREF(m); return NULL; }
+    Py_INCREF(ExtXYZError);
+    if (PyModule_AddObject(m, "ExtXYZError", ExtXYZError) != 0) {
+        Py_DECREF(ExtXYZError);
+        Py_DECREF(m);
+        return NULL;
+    }
+    return m;
+}

--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,22 @@ python = pymod.find_installation(
 host_system = host_machine.system()
 cc = meson.get_compiler('c')
 
+# numpy headers for the C-API fast read path in the _extxyz extension. Resolved
+# non-fatally: a standalone C/Fortran/Julia build without numpy still configures
+# (the extension then falls back to the ctypes-only marshalling path).
+np_cmd = run_command(python, '-c',
+    'import numpy; print(numpy.get_include())', check: false)
+have_numpy = np_cmd.returncode() == 0
+if have_numpy
+  # Pass as a -I compile arg rather than include_directories(): numpy's include
+  # path is absolute and may sit inside the source tree (e.g. an in-repo .venv),
+  # which include_directories() rejects. -I works regardless of location.
+  numpy_inc_arg = '-I' + np_cmd.stdout().strip()
+  message('numpy headers found: building _extxyz with the C-API fast read path')
+else
+  message('numpy headers not found: _extxyz will use the ctypes read path only')
+endif
+
 # Determine MSVC runtime library (for PCRE2 library name)
 vs_crt = 'release'
 vs_crt_opt = get_option('b_vscrt')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["meson>=1.0.0", "meson-python>=0.13.0", "ninja", "pyleri>=1.3.3"]
+requires = ["meson>=1.0.0", "meson-python>=0.13.0", "ninja", "pyleri>=1.3.3", "numpy>=1.13.0"]
 build-backend = "mesonpy"
 
 [project]
@@ -67,7 +67,9 @@ wheel.exclude = [
 
 [tool.cibuildwheel]
 test-requires = "pytest"
-test-command = "pytest -v {package}/tests"
+# Assert the wheel actually shipped the C-API fast read path before running the
+# suite, so a silent ctypes fallback fails the build instead of shipping slow.
+test-command = "python {package}/tools/assert_c_read_path.py && pytest -v {package}/tests"
 
 [tool.cibuildwheel.linux]
 before-all = "which yum && yum install -y pcre2-devel zlib-devel"

--- a/python/extxyz/cextxyz.py
+++ b/python/extxyz/cextxyz.py
@@ -71,6 +71,23 @@ extxyz.print_dict.args = [Dict_entry_ptr]
 
 extxyz.free_dict.args = [Dict_entry_ptr]
 
+# The same _extxyz .so is also importable as a CPython C-API module when built
+# with numpy (libextxyz/pyext.c). When present it provides `read_frame`, which
+# does the read + dict marshalling entirely in C — far faster than the per-node
+# ctypes loop in c_to_py_dict. A numpy-less C/Fortran/Julia build has no
+# PyInit__extxyz, so this import fails and we fall back to the ctypes path.
+try:
+    from . import _extxyz as _ext_mod
+    _HAVE_C_READ = hasattr(_ext_mod, 'read_frame')
+except ImportError:
+    _ext_mod = None
+    _HAVE_C_READ = False
+
+# Escape hatch: force the legacy ctypes marshalling (for A/B benchmarking and as
+# a safety valve). Any value other than ''/0/false enables it.
+_USE_LEGACY_MARSHAL = os.environ.get('EXTXYZ_LEGACY_MARSHAL', '').lower() \
+    not in ('', '0', 'false', 'no')
+
 
 def _read_contiguous_strings(addr, width, count):
     """Read a per-atom string column stored by the C parser as one contiguous
@@ -284,7 +301,13 @@ def cfseek(fp, offset, whence):
 
 
 def read_frame_dicts(fp, verbose=False, comment=None, use_regex=False):
-    """Read a single frame using extxyz_read_ll_opts() C function
+    """Read a single frame, returning ``(nat, info, arrays)``.
+
+    Uses the C-API ``_extxyz.read_frame`` fast path (read + dict marshalling in
+    C) when available; otherwise falls back to the ctypes marshalling in
+    :func:`read_frame_dicts_ctypes`. ``verbose`` (which dumps the C dicts to
+    stdout) always uses the ctypes path. Set ``EXTXYZ_LEGACY_MARSHAL=1`` to
+    force the ctypes path.
 
     Args:
         fp (FILE_ptr): open file pointer, as returned by `cfopen()`
@@ -294,6 +317,27 @@ def read_frame_dicts(fp, verbose=False, comment=None, use_regex=False):
             with the fast whitespace tokenizer, which validates each field.
             If True, use the slower PCRE2 regex parser instead (marginally
             stricter than the tokenizer on numeric edge cases).
+
+    Returns:
+        nat, info, arrays: int, dict, dict
+    """
+    if _HAVE_C_READ and not _USE_LEGACY_MARSHAL and not verbose:
+        try:
+            return _ext_mod.read_frame(_kv_grammar.value, fp.value,
+                                       0 if use_regex else 1, comment)
+        except _ext_mod.ExtXYZError as exc:
+            # Re-raise as the canonical cextxyz.ExtXYZError so callers (and
+            # tests) catch one exception type regardless of backend. Normalise
+            # the message exactly as the legacy path did (.strip().replace) so
+            # core.py's "Failed to parse string" fallback still matches.
+            raise ExtXYZError(str(exc).strip().replace('\n', '')) from None
+    return read_frame_dicts_ctypes(fp, verbose=verbose, comment=comment,
+                                   use_regex=use_regex)
+
+
+def read_frame_dicts_ctypes(fp, verbose=False, comment=None, use_regex=False):
+    """Read a single frame using extxyz_read_ll_opts() and marshal the C
+    dictionaries to Python via ctypes (the original, slower path).
 
     Returns:
         nat, info, arrays: int, dict, dict

--- a/tests/test_marshal_parity.py
+++ b/tests/test_marshal_parity.py
@@ -1,0 +1,123 @@
+"""Parity tests: the C-API marshalling (_extxyz.read_frame, libextxyz/pyext.c)
+must produce output byte-for-byte identical to the legacy ctypes marshalling
+(cextxyz.c_to_py_dict). Both go through cextxyz.read_frame_dicts; the dispatcher
+honours cextxyz._USE_LEGACY_MARSHAL per call, so we read each file both ways.
+"""
+import numpy as np
+import pytest
+
+import extxyz
+from extxyz import cextxyz
+
+pytestmark = pytest.mark.skipif(
+    not cextxyz._HAVE_C_READ,
+    reason="C-API fast read path not built (numpy-less build)")
+
+
+# A comment line exercising every info type: str/bool/int/float scalars,
+# 1D int/float/bool arrays, a 2D int array (virial) and the 3x3 Lattice.
+COMPLEX_COMMENT = (
+    'str=astring quot="quoted value" false_value=F integer=22 floating=1.1 '
+    'int_array="1 2 3" float_array="3.3 4.4" '
+    'virial="[[1, 2, 3], [4, 5, 6], [7, 8, 9]]" '
+    'Lattice="4.3 0 0 0 3.3 0 0 0 7.0" '
+    'scientific_float=1.2e7 sci_array="1.2 2200 40 0.33 0.02" '
+    'bool_array="T F T F" energy="-79.178441" pbc="T T F" '
+    'Properties=species:S:1:pos:R:3'
+)
+
+# A frame with rich per-atom columns: string (species), float matrix (pos,
+# force), int vector (tag), bool vector (flag).
+RICH_PERATOM = (
+    '3\n'
+    'Lattice="10 0 0 0 10 0 0 0 10" '
+    'Properties=species:S:1:pos:R:3:tag:I:1:flag:L:1:force:R:3\n'
+    'C 0.1 0.2 0.3 5 T 1.5 -2.5 3.5\n'
+    'Hh 1.1 -1.2 1.3 -7 F 0.0 0.0 -0.0\n'
+    'O 2.25 2.5 -2.75 0 T 9.0 8.0 7.0\n'
+)
+
+FRAMES = {
+    'complex_info': '1\n{}\nH 1.0 1.0 1.0\n'.format(COMPLEX_COMMENT),
+    'rich_peratom': RICH_PERATOM,
+    'multi_frame': RICH_PERATOM + '1\n{}\nH 1.0 1.0 1.0\n'.format(COMPLEX_COMMENT),
+}
+
+
+@pytest.fixture(autouse=True)
+def _restore_marshal_flag():
+    saved = cextxyz._USE_LEGACY_MARSHAL
+    yield
+    cextxyz._USE_LEGACY_MARSHAL = saved
+
+
+def _read(path, legacy, use_regex):
+    cextxyz._USE_LEGACY_MARSHAL = legacy
+    out = extxyz.read_dicts(str(path), use_regex=use_regex)
+    return out if isinstance(out, list) else [out]
+
+
+def _assert_value_equal(label, a, b):
+    a_arr, b_arr = isinstance(a, np.ndarray), isinstance(b, np.ndarray)
+    assert a_arr == b_arr, f"{label}: array-ness {a_arr} != {b_arr}"
+    if a_arr:
+        assert a.dtype == b.dtype, f"{label}: dtype {a.dtype} != {b.dtype}"
+        assert a.shape == b.shape, f"{label}: shape {a.shape} != {b.shape}"
+        if a.dtype.kind == 'f':
+            # bit-identical, not merely close
+            assert np.array_equal(a.view('u8'), b.view('u8')), f"{label}: float bits differ"
+        else:
+            assert np.array_equal(a, b), f"{label}: values differ"
+    else:
+        assert type(a) is type(b), f"{label}: type {type(a)} != {type(b)}"
+        assert a == b, f"{label}: {a!r} != {b!r}"
+
+
+@pytest.mark.parametrize('use_regex', [False, True])
+@pytest.mark.parametrize('name', list(FRAMES))
+def test_c_marshalling_matches_legacy(tmp_path, name, use_regex):
+    path = tmp_path / f'{name}.xyz'
+    path.write_text(FRAMES[name])
+
+    new = _read(path, legacy=False, use_regex=use_regex)
+    old = _read(path, legacy=True, use_regex=use_regex)
+
+    assert len(new) == len(old)
+    for i, (a, b) in enumerate(zip(new, old)):
+        assert a.natoms == b.natoms, f"frame {i}: natoms"
+        _assert_value_equal(f"frame {i}.cell", a.cell, b.cell)
+        assert (a.pbc == b.pbc).all(), f"frame {i}: pbc"
+        assert set(a.info) == set(b.info), f"frame {i}: info keys"
+        for k in a.info:
+            _assert_value_equal(f"frame {i}.info[{k!r}]", a.info[k], b.info[k])
+        assert set(a.arrays) == set(b.arrays), f"frame {i}: arrays keys"
+        for k in a.arrays:
+            _assert_value_equal(f"frame {i}.arrays[{k!r}]", a.arrays[k], b.arrays[k])
+
+
+def test_c_path_raises_eof_at_end():
+    """read_frame raises EOFError past the last frame, just like the ctypes path
+    (this is what lets iread_dicts terminate)."""
+    import tempfile, os
+    fd, name = tempfile.mkstemp(suffix='.xyz')
+    os.write(fd, b'1\nProperties=species:S:1:pos:R:3\nH 0 0 0\n')
+    os.close(fd)
+    try:
+        fp = cextxyz.cfopen(name, 'r')
+        try:
+            cextxyz._ext_mod.read_frame(cextxyz._kv_grammar.value, fp.value, 1, None)
+            with pytest.raises(EOFError):
+                cextxyz._ext_mod.read_frame(cextxyz._kv_grammar.value, fp.value, 1, None)
+        finally:
+            cextxyz.cfclose(fp)
+    finally:
+        os.unlink(name)
+
+
+@pytest.mark.parametrize('legacy', [False, True])
+def test_malformed_raises_extxyz_error(tmp_path, legacy):
+    """Both backends reject a malformed per-atom line with ExtXYZError."""
+    path = tmp_path / 'bad.xyz'
+    path.write_text('1\nProperties=species:S:1:pos:R:3\nH NOTANUM 0 0\n')
+    with pytest.raises(cextxyz.ExtXYZError):
+        _read(path, legacy=legacy, use_regex=False)

--- a/tools/assert_c_read_path.py
+++ b/tools/assert_c_read_path.py
@@ -1,0 +1,19 @@
+"""Fail if the installed _extxyz lacks the C-API fast read path.
+
+Every CI-built wheel is built with numpy in the build environment, so
+``cextxyz._HAVE_C_READ`` must be True. A False here means the wheel silently
+fell back to the slower ctypes marshalling (e.g. numpy headers were missing at
+build time, or PyInit__extxyz wasn't exported) — which we want to catch loudly
+rather than ship a quietly-slow wheel. Run as part of cibuildwheel's
+test-command.
+"""
+import sys
+
+from extxyz import cextxyz
+
+if not cextxyz._HAVE_C_READ:
+    sys.exit("ERROR: _extxyz was built without the C-API fast read path; "
+             "the package fell back to the ctypes marshalling. Check that "
+             "numpy headers were available at build time (and, on Windows, "
+             "that PyInit__extxyz is exported in _extxyz_pyext.def).")
+print("OK: _extxyz C-API fast read path is active (cextxyz._HAVE_C_READ=True)")


### PR DESCRIPTION
## What

Move the C read path's dict marshalling into the `_extxyz` extension. After the C reader parses a frame, it previously handed the data back to Python by walking the `DictEntry` linked list one field at a time through `ctypes` (`c_to_py_dict`) — ~1.09M `ctypes.cast` + 737k `copy.copy` across a 76k-frame read, pure boundary overhead that dominates files with **many small frames**.

This adds a CPython C-API entry point (`_extxyz.read_frame`, in `libextxyz/pyext.c`) that builds the `info`/`arrays` dicts of numpy arrays / scalars directly in C and frees the C dicts, replacing the per-node Python loop.

## Why it's safe

- **Bit-identical** to the old path. `tests/test_marshal_parity.py` reads each fixture through both backends (and both `use_regex` values) and asserts equal keys, dtypes, shapes, types, and **bit-identical floats**. Verified additionally on all 76,346 frames of a real training set: 0 mismatches.
- **Graceful fallback.** `cextxyz.read_frame_dicts` dispatches to the C path only when present; otherwise it uses the preserved `read_frame_dicts_ctypes`. `EXTXYZ_LEGACY_MARSHAL=1` forces the legacy path.
- **C core untouched.** Zero diff to `extxyz.c` / the `extxyz.h` ABI. `pyext.c` is compiled **only** into the `_extxyz` Python extension — never the standalone `libextxyz` shared library or the C/Fortran (`fextxyz`/QUIP)/Julia consumers.
- **No leaks.** `leaks` over 12k frames across success/EOF/scattered-string/error paths: 0 leaks, 0 bytes.

## Build / packaging

- numpy is now a **build-time** dependency (already a runtime dep). The numpy include is resolved **non-fatally** in `meson.build`: a numpy-less standalone C/Fortran/Julia build still configures and just uses the ctypes path. Verified both a numpy-present and a numpy-less `meson setup`/`compile`.
- Windows: a second module-def (`_extxyz_pyext.def`) exports `PyInit__extxyz` so the module is importable; the numpy-less build keeps the original `.def` (no unresolved-export link error).
- CI now asserts every built wheel and the source build actually shipped the C path (`tools/assert_c_read_path.py`), so a silent ctypes fallback fails the build instead of shipping quietly slow.

## Measured (76,346 frames, ~27 atoms/frame)

| metric | before | after | speedup |
|---|--:|--:|--:|
| dict-level parse (`read_dicts`) | 3.6 s | 2.3 s | ~1.5× |
| full ASE read (`format='cextxyz'`) | 4.8 s | 3.3 s | 1.48× |

Most visible on many-small-frame files / rich comment lines, where per-frame overhead — not per-atom parsing — dominates; on the large single-frame Cu benchmark the effect is small.

## Notes for reviewers

- The remaining gap to hand-written parsers (e.g. chemfiles) is now mostly the libcleri comment-line grammar — a possible follow-up (hand-written C key=value scanner), intentionally out of scope here.
- Benchmark/verification scripts included under `benchmarks/` (`bench_mad.py`, `scope_comment.py`, `verify_marshal.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
