### PR TITLE
docs: clarify sdist/source-build requirements in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The latest development version can be installed via
 pip install git+https://github.com/libAtoms/extxyz
 ```
 
-This requires Python 3.10+ and a working C compiler, plus the PCRE2 and libcleri libraries. `libcleri` is included here as a submodule and will be compiled automatically, but you may need to install PCRE2 with something similar to one of the following commands. NumPy is also needed at build time (it is already a runtime dependency): its C headers build the `_extxyz` extension's fast read path. A build without NumPy headers still works — it falls back to the slower ctypes read path.
+This builds the C extension from source, so it needs **Python 3.10+** and a **C compiler** (C only — the Fortran `fextxyz` bindings are optional and off by default). `libcleri` is bundled (a git submodule in the repo, vendored into the sdist) and always compiled from source. **PCRE2** is the one external native library: the build uses a system PCRE2 if pkg-config finds one (install it with a command below), otherwise it downloads and compiles PCRE2 from the bundled meson wrap (this needs network access). **NumPy** is also a build-time dependency (it is already a runtime one): its C headers build the `_extxyz` fast read path — a build without them still works, falling back to the slower ctypes path. The remaining build tools (`meson`, `ninja`, `pyleri` for the grammar codegen) are installed automatically by pip.
 
 ```
 brew install pcre2          # macOS with Homebrew
@@ -25,7 +25,7 @@ sudo apt-get install libpcre2-dev   # Ubuntu / Debian
 vcpkg install pcre2:x64-windows     # Windows (via vcpkg)
 ```
 
-Binary wheels for Linux, macOS (arm64 and x86_64), and Windows are built in the GitHub CI for each tagged [release](https://github.com/libAtoms/extxyz/releases) and bundle PCRE2 and libcleri, so an end-user `pip install extxyz` does not need either system library.
+Binary wheels (CPython 3.10–3.14) for Linux, macOS (arm64 and x86_64), and Windows are built in the GitHub CI for each tagged [release](https://github.com/libAtoms/extxyz/releases) and bundle PCRE2 and libcleri, so an end-user `pip install extxyz` needs no compiler or system libraries. A source distribution (sdist) is also published; installing from it (e.g. on a platform without a wheel) builds from source and needs the toolchain above.
 
 Stable releases are made to PyPI, so you can install with
 


### PR DESCRIPTION
## What

Make the README's source-build requirements accurate, now that the comment-line dispatcher landed and v0.4.4 ships CPython 3.10–3.14 wheels + an sdist.

Two paragraphs in the install section:

- **Build deps**: a **C compiler only** (Fortran `fextxyz` is optional/off by default); **libcleri** is bundled (submodule in the repo, vendored into the sdist) and always built from source — no longer an external dep; **PCRE2** is the one external native library — system via pkg-config, else downloaded+compiled from the bundled meson wrap (needs network), **not vendored**; **NumPy** is a build-time dep (C-API headers for the fast read path); meson/ninja/pyleri are auto-installed by pip.
- **Wheels/sdist**: wheels cover **CPython 3.10–3.14**, and a **source distribution is also published**.

## Why

Verified against the published v0.4.4 sdist: a clean `uv pip install --no-binary extxyz` builds from source, but it links a **system** PCRE2 (`/opt/homebrew/opt/pcre2/...`) — the sdist ships only `subprojects/pcre2.wrap` (a download pointer), so PCRE2 must be present or downloadable, while libcleri is genuinely bundled. The old wording ("requires the PCRE2 and libcleri libraries") blurred that distinction.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
